### PR TITLE
Sanitize file/dir parameter

### DIFF
--- a/vendor/cmacc-app/cmacc_helpers.php
+++ b/vendor/cmacc-app/cmacc_helpers.php
@@ -11,6 +11,7 @@ if (!isset($_REQUEST['action'])) {
 
 if (isset($_REQUEST['file'])) {
     $dir = $_REQUEST['file'];
+    $dir = preg_replace('~[^\w/.,_-]~u', '_', $dir);
     $dir = str_replace('..', '', $dir);
 } else {
     $dir = './';


### PR DESCRIPTION
Allow letters, numbers, period, comma, underscore, dash. All filenames in Doc
should be allowed, while restricting any other characters such as `<` or `;`.